### PR TITLE
Fix build on non-Linux platforms and allow baud rate to be set on the command line.

### DIFF
--- a/sw/regdefs.h
+++ b/sw/regdefs.h
@@ -52,7 +52,7 @@
 
 #define	R_MEM		0x00004000
 
-static const int	BAUDRATE=4000000;
+#define DEFBAUDRATE	4000000
 
 typedef	struct {
 	unsigned	m_addr;


### PR DESCRIPTION
I built this on MacOSX and used it to talk to a Spartan 3 with a hacked up version of testbus.v via an FTDI USB UART.
